### PR TITLE
evaluate responseToResult before mapping it onwards

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -198,9 +198,9 @@ function mapExpect(func, expect)
 {
 	return {
 		responseType: expect.responseType,
-		responseToResult: function(x) {
-			var y = expect.responseToResult(x);
-			return A2(_elm_lang$core$Result$map, func, y);
+		responseToResult: function(response) {
+			var convertedResponse = expect.responseToResult(response);
+			return A2(_elm_lang$core$Result$map, func, convertedResponse);
 		}
 	};
 }

--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -198,7 +198,10 @@ function mapExpect(func, expect)
 {
 	return {
 		responseType: expect.responseType,
-		responseToResult: A2(_elm_lang$core$Result$map, func, expect.responseToResult)
+		responseToResult: function(x) {
+			var y = expect.responseToResult(x);
+			return A2(_elm_lang$core$Result$map, func, y);
+		}
 	};
 }
 


### PR DESCRIPTION
# Problem 

Example failing code: https://gist.github.com/pablohirafuji/9e8d8b1310e9a22947a100502578b892

The problem definition is stated here -> https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/elm-dev/tNU46L2j7v4/bHYQ34azAwAJ

tl;dr `Uncaught TypeError: responseToResult is not a function` was being thrown when attemping to use `Http.Progress`

# Solution

- The error was being caused by the fact that `mapExpect` was attempting to apply `Result.map` to a function object, and not a result
- This lead to an object being used in `handleResponse`, throwing the above error
- As a result, it seemed like the solution is to first evaluate the response with the current `responseToResult` before mapping it
- Otherwise, the object was being mapped, but always mapping incorrectly as it was expecting a result, not a function.


# Thoughts

💭  This change makes it so that you can no longer use `mapExpect` twice on an expect object. As far as I could tell, this is not a problem based on the implementation.

:thought_balloon: It's almost definitely better to fix this in another way, I think. 