### PR TITLE
Fix issue setting xhr.timeout to an object

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -85,7 +85,12 @@ function configureRequest(xhr, request)
 
 	A2(_elm_lang$core$List$map, setHeader, request.headers);
 	xhr.responseType = request.expect.responseType;
-	xhr.timeout = request.timeout;
+
+	if (request.timeout.ctor === 'Just')
+	{
+		xhr.timeout = request.timeout._0;
+	}
+
 	xhr.withCredentials = request.withCredentials;
 }
 


### PR DESCRIPTION
Previously, if the request timeout was Nothing, it would set the timeout
on the XHR request to the Elm representation of Maybe, i.e.
`{ ctor: 'Nothing' }`. This was causing issues in Elm Native, where
Objective-C was type-checking the value of timeout as a number, and it
was coming back as a dictionary.

This solves the issue by only setting the timeout on the XHR request if
the value is `Just`, and setting it to the value itself instead of the
Elm representation of that value.