### PR TITLE
Add "ignoreResponseBody" expectation.

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -5,7 +5,7 @@ module Http exposing
   , request
   , Header, header
   , Body, emptyBody, jsonBody, stringBody, multipartBody, Part, stringPart
-  , Expect, expectString, expectJson, expectStringResponse, Response
+  , Expect, ignoreResponseBody, expectString, expectJson, expectStringResponse, Response
   , encodeUri, decodeUri, toTask
   )
 
@@ -349,6 +349,11 @@ stringPart =
 type alias Expect a =
   Http.Internal.Expect a
 
+{-| Ignore the response body. (Useful for empty bodies!)
+-}
+ignoreResponseBody : Expect ()
+ignoreResponseBody =
+    expectStringResponse (\response -> Ok ())
 
 {-| Expect the response body to be a `String`.
 -}


### PR DESCRIPTION
Based on #12, it's not obvious how to deal with empty response bodies.

I've added a new expectation to the Expect zoo which can be used to ignore a request body. This was do-able with `expectString`, but wasn't obvious and didn't have a representative type signature.

While doing this, I had a few questions:

- I couldn't come up with a name for this that fit the `Expect` sentence pattern: I thought about calling it `expectEmptyBody`, but it doesn't actually do a check - it just ignores it. Any suggestions?
- Should `expect` be a parameter to `get` and `post`? (Obviously this is a breaking change, but I wonder whether expecting JSON on all responses is too opinionated.)

Thanks for reading!